### PR TITLE
Hosts social link url fix

### DIFF
--- a/src/lib/hosts/HostSocialLink.svelte
+++ b/src/lib/hosts/HostSocialLink.svelte
@@ -22,7 +22,7 @@
 {/if}
 
 {#if host.url}
-	<a href={`https://github.com/${host.url}`} target="_blank" class="social-icon">
+	<a href={host.url} target="_blank" class="social-icon">
 		<Icon name="monitor" title={`${host.name}'s website'`} />
 	</a>
 {/if}


### PR DESCRIPTION
Hosts website url was prepending the github url, so removed the hardcoded github url